### PR TITLE
Enable handling of texture files that are not contained in hierarchies below the pmx file.

### DIFF
--- a/src/Loader/referenceFileResolver.ts
+++ b/src/Loader/referenceFileResolver.ts
@@ -36,6 +36,7 @@ export class ReferenceFileResolver<T extends File | IArrayBufferFile = File | IA
      * File list that can be resolved
      */
     public readonly files: readonly T[];
+    private readonly _rootUrl: string;
     private readonly _fileRootId: string;
     private readonly _fileMap: Map<string, T> = new Map<string, T>();
 
@@ -48,9 +49,8 @@ export class ReferenceFileResolver<T extends File | IArrayBufferFile = File | IA
      * @param fileRootId File root id for give the unique id for the files
      */
     public constructor(files: readonly T[], rootUrl: string, fileRootId: string) {
-        rootUrl = pathNormalize(rootUrl);
-
         this.files = files;
+        this._rootUrl = pathNormalize(rootUrl);
         this._fileRootId = fileRootId;
 
         if (files.length === 0) return;
@@ -58,15 +58,12 @@ export class ReferenceFileResolver<T extends File | IArrayBufferFile = File | IA
         if (files[0] instanceof File) {
             for (const file of files) {
                 const fileRelativePath = pathNormalize((file as File).webkitRelativePath);
-
-                if (!fileRelativePath.startsWith(rootUrl)) continue;
-
-                const relativePath = fileRootId + pathNormalize(fileRelativePath.slice(rootUrl.length));
+                const relativePath = fileRootId + pathNormalize(fileRelativePath);
                 this._fileMap.set(pathNormalize(relativePath).toUpperCase(), file);
             }
         } else {
             for (const file of files) {
-                const relativePath = fileRootId + pathNormalize((file as IArrayBufferFile).relativePath);
+                const relativePath = fileRootId + pathNormalize(this._rootUrl + (file as IArrayBufferFile).relativePath);
                 this._fileMap.set(pathNormalize(relativePath).toUpperCase(), file);
             }
         }
@@ -78,7 +75,7 @@ export class ReferenceFileResolver<T extends File | IArrayBufferFile = File | IA
      * @returns Full path
      */
     public createFullPath(relativePath: string): string {
-        return this._fileRootId + pathNormalize(relativePath);
+        return this._fileRootId + pathNormalize(this._rootUrl + relativePath);
     }
 
     /**


### PR DESCRIPTION
# Phenomenon
When texture files are in a different hierarchy than the pmx file as shown below, textures cannot be referenced in the `PMX to BPMX Converter`.

```
model/cube.pmx
textures/texture.png
```

This type of pmx file can be generated by exporting with the `Copy textures` option turned off using blender's mmd_tools. A sample is included in the attached [mmd.zip](https://github.com/user-attachments/files/19408487/mmd.zip).

# Cause
In this file, the texture path within the pmx file is set with a path that includes `..` such as `..\textures\texture.png`. The current ReferenceFileResolver converts the path using pathNormalize() without resolving relativePaths that include `..`, which causes the leading `..` to be deleted (due to pop() being called on an empty resultArray).

# Proposed fix:
In ReferenceFileResolver, instead of using the relativePath as is, combine it with rootUrl before use. This allows paths containing `..` to be resolved properly before being used. Also, the current implementation assumes that `the beginning of webkitRelativePath matches rootUrl`, but since this may not always be the case with these files, this condition has been removed.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Enhanced the mechanism for generating relative and full file paths, ensuring improved consistency and reliability in file referencing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->