### PR TITLE
rename AnimationGroup to AnimationContainer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.69.0 (2025-07-17)
+
+- rename `MmdCameraAnimationGroup` to `MmdCameraAnimationContainer`
+- rename `MmdModelAnimationGroup` to `MmdModelAnimationContainer`
+- rename `MmdRuntimeCameraAnimationGroup` to `MmdRuntimeCameraAnimationContainer`
+- rename `MmdRuntimeModelAnimationGroup` to `MmdRuntimeModelAnimationContainer`
+
 ## 0.68.0 (2025-07-16)
 
 - BPMX format updated to 3.0.0. 2.X files are no longer supported

--- a/src/Loader/Animation/mmdCameraAnimationContainer.ts
+++ b/src/Loader/Animation/mmdCameraAnimationContainer.ts
@@ -18,7 +18,7 @@ import type { MmdCameraAnimationTrack } from "./mmdAnimationTrack";
  *
  * It aims to utilize the animation runtime of babylon.js
  */
-export class MmdCameraAnimationGroup implements IMmdAnimation {
+export class MmdCameraAnimationContainer implements IMmdAnimation {
     /**
      * Animation name for identification
      */
@@ -61,7 +61,7 @@ export class MmdCameraAnimationGroup implements IMmdAnimation {
      */
     public constructor(
         mmdAnimation: MmdAnimationBase,
-        builder: IMmdCameraAnimationGroupBuilder
+        builder: IMmdCameraAnimationContainerBuilder
     ) {
         const name = this.name = mmdAnimation.name;
 
@@ -93,7 +93,7 @@ export class MmdCameraAnimationGroup implements IMmdAnimation {
 /**
  * Mmd camera animation builder for constructing mmd camera animation group
  */
-export interface IMmdCameraAnimationGroupBuilder {
+export interface IMmdCameraAnimationContainerBuilder {
     /**
      * Create mmd camera position animation
      * @param rootName root animation name
@@ -132,7 +132,7 @@ export interface IMmdCameraAnimationGroupBuilder {
  *
  * This has some loss of curve shape, but it converts animations reliably while maintaining a small amount of keyframes
  */
-export class MmdCameraAnimationGroupHermiteBuilder implements IMmdCameraAnimationGroupBuilder {
+export class MmdCameraAnimationContainerHermiteBuilder implements IMmdCameraAnimationContainerBuilder {
     /**
      * Create mmd camera position animation
      * @param rootName root animation name
@@ -317,7 +317,7 @@ export class MmdCameraAnimationGroupHermiteBuilder implements IMmdCameraAnimatio
  *
  * This method samples the bezier curve with 30 frames to preserve the shape of the curve as much as possible. However, it will use a lot of memory
  */
-export class MmdCameraAnimationGroupSampleBuilder implements IMmdCameraAnimationGroupBuilder {
+export class MmdCameraAnimationContainerSampleBuilder implements IMmdCameraAnimationContainerBuilder {
     /**
      * Create mmd camera position animation
      * @param rootName root animation name
@@ -548,7 +548,7 @@ export class MmdCameraAnimationGroupSampleBuilder implements IMmdCameraAnimation
  *
  * This method is not compatible with the Animation Curve Editor, but it allows you to import animation data completely lossless
  */
-export class MmdCameraAnimationGroupBezierBuilder implements IMmdCameraAnimationGroupBuilder {
+export class MmdCameraAnimationContainerBezierBuilder implements IMmdCameraAnimationContainerBuilder {
     /**
      * Create mmd camera position animation
      * @param rootName root animation name

--- a/src/Loader/Animation/mmdModelAnimationContainer.ts
+++ b/src/Loader/Animation/mmdModelAnimationContainer.ts
@@ -83,7 +83,7 @@ class VisibilityProxy {
  *
  * It aims to utilize the animation runtime of babylon.js
  */
-export class MmdModelAnimationGroup implements IMmdAnimation {
+export class MmdModelAnimationContainer implements IMmdAnimation {
     /**
      * Animation name for identification
      */
@@ -161,7 +161,7 @@ export class MmdModelAnimationGroup implements IMmdAnimation {
      */
     public constructor(
         mmdAnimation: MmdAnimationBase,
-        builder: IMmdModelAnimationGroupBuilder
+        builder: IMmdModelAnimationContainerBuilder
     ) {
         const name = this.name = mmdAnimation.name;
 
@@ -323,7 +323,7 @@ export class MmdModelAnimationGroup implements IMmdAnimation {
 /**
  * Mmd model animation builder for constructing mmd model animation group
  */
-export interface IMmdModelAnimationGroupBuilder {
+export interface IMmdModelAnimationContainerBuilder {
     /**
      * Create mmd model bone position animation
      * @param rootName root animation name
@@ -380,7 +380,7 @@ export interface IMmdModelAnimationGroupBuilder {
  *
  * For reduce duplication of code
  */
-export abstract class MmdModelAnimationGroupBuilderBase implements IMmdModelAnimationGroupBuilder {
+export abstract class MmdModelAnimationContainerBuilderBase implements IMmdModelAnimationContainerBuilder {
     /**
      * Create mmd model bone position animation
      * @param rootName root animation name
@@ -511,7 +511,7 @@ export abstract class MmdModelAnimationGroupBuilderBase implements IMmdModelAnim
  *
  * This has some loss of curve shape, but it converts animations reliably while maintaining a small amount of keyframes
  */
-export class MmdModelAnimationGroupHermiteBuilder extends MmdModelAnimationGroupBuilderBase {
+export class MmdModelAnimationContainerHermiteBuilder extends MmdModelAnimationContainerBuilderBase {
     /**
      * Create mmd model bone position animation
      * @param rootName root animation name
@@ -636,7 +636,7 @@ export class MmdModelAnimationGroupHermiteBuilder extends MmdModelAnimationGroup
  *
  * This method samples the bezier curve with 30 frames to preserve the shape of the curve as much as possible. However, it will use a lot of memory
  */
-export class MmdModelAnimationGroupSampleBuilder extends MmdModelAnimationGroupBuilderBase {
+export class MmdModelAnimationContainerSampleBuilder extends MmdModelAnimationContainerBuilderBase {
     /**
      * Create mmd model bone position animation
      * @param rootName root animation name
@@ -758,7 +758,7 @@ export class MmdModelAnimationGroupSampleBuilder extends MmdModelAnimationGroupB
  *
  * This method is not compatible with the Animation Curve Editor, but it allows you to import animation data completely lossless
  */
-export class MmdModelAnimationGroupBezierBuilder extends MmdModelAnimationGroupBuilderBase {
+export class MmdModelAnimationContainerBezierBuilder extends MmdModelAnimationContainerBuilderBase {
     /**
      * Create mmd model bone position animation
      * @param rootName root animation name

--- a/src/Runtime/Animation/mmdCompositeRuntimeCameraAnimation.ts
+++ b/src/Runtime/Animation/mmdCompositeRuntimeCameraAnimation.ts
@@ -155,7 +155,7 @@ export class MmdCompositeRuntimeCameraAnimation implements IMmdRuntimeCameraAnim
                 const runtimeAnimation = (animation as IMmdBindableCameraAnimation).createRuntimeCameraAnimation(camera);
                 runtimeAnimations[i] = runtimeAnimation;
             } else if ((animation as IMmdBindableModelAnimation).createRuntimeModelAnimation === undefined) {
-                throw new Error(`animation ${animation.name} is not bindable. are you missing import "babylon-mmd/esm/Runtime/Animation/mmdRuntimeCameraAnimation" or "babylon-mmd/esm/Runtime/Animation/mmdRuntimeCameraAnimationGroup"?`);
+                throw new Error(`animation ${animation.name} is not bindable. are you missing import "babylon-mmd/esm/Runtime/Animation/mmdRuntimeCameraAnimation" or "babylon-mmd/esm/Runtime/Animation/mmdRuntimeCameraAnimationContainer"?`);
             }
         }
 
@@ -165,7 +165,7 @@ export class MmdCompositeRuntimeCameraAnimation implements IMmdRuntimeCameraAnim
                 const runtimeAnimation = (animation as IMmdBindableCameraAnimation).createRuntimeCameraAnimation(camera);
                 runtimeAnimations.push(runtimeAnimation);
             } else if ((animation as IMmdBindableModelAnimation).createRuntimeModelAnimation === undefined) {
-                throw new Error(`animation ${animation.name} is not bindable. are you missing import "babylon-mmd/esm/Runtime/Animation/mmdRuntimeCameraAnimation" or "babylon-mmd/esm/Runtime/Animation/mmdRuntimeCameraAnimationGroup"?`);
+                throw new Error(`animation ${animation.name} is not bindable. are you missing import "babylon-mmd/esm/Runtime/Animation/mmdRuntimeCameraAnimation" or "babylon-mmd/esm/Runtime/Animation/mmdRuntimeCameraAnimationContainer"?`);
             } else {
                 runtimeAnimations.push(null);
             }

--- a/src/Runtime/Animation/mmdCompositeRuntimeModelAnimation.ts
+++ b/src/Runtime/Animation/mmdCompositeRuntimeModelAnimation.ts
@@ -513,7 +513,7 @@ export class MmdCompositeRuntimeModelAnimation implements IMmdRuntimeModelAnimat
                 const runtimeAnimation = (animation as IMmdBindableModelAnimation<IMmdRuntimeModelAnimationWithBindingInfo>).createRuntimeModelAnimation(model, retargetingMap, logger);
                 runtimeAnimations[i] = runtimeAnimation;
             } else if ((animation as IMmdBindableModelAnimation).createRuntimeModelAnimation === undefined) {
-                throw new Error(`animation ${animation.name} is not bindable. are you missing import "babylon-mmd/esm/Runtime/Animation/mmdRuntimeModelAnimation" or "babylon-mmd/esm/Runtime/Animation/mmdRuntimeModelAnimationGroup"?`);
+                throw new Error(`animation ${animation.name} is not bindable. are you missing import "babylon-mmd/esm/Runtime/Animation/mmdRuntimeModelAnimation" or "babylon-mmd/esm/Runtime/Animation/mmdRuntimeModelAnimationContainer"?`);
             }
         }
 
@@ -523,7 +523,7 @@ export class MmdCompositeRuntimeModelAnimation implements IMmdRuntimeModelAnimat
                 const runtimeAnimation = (animation as IMmdBindableModelAnimation<IMmdRuntimeModelAnimationWithBindingInfo>).createRuntimeModelAnimation(model, retargetingMap, logger);
                 runtimeAnimations.push(runtimeAnimation);
             } else if ((animation as IMmdBindableModelAnimation).createRuntimeModelAnimation === undefined) {
-                throw new Error(`animation ${animation.name} is not bindable. are you missing import "babylon-mmd/esm/Runtime/Animation/mmdRuntimeModelAnimation" or "babylon-mmd/esm/Runtime/Animation/mmdRuntimeModelAnimationGroup"?`);
+                throw new Error(`animation ${animation.name} is not bindable. are you missing import "babylon-mmd/esm/Runtime/Animation/mmdRuntimeModelAnimation" or "babylon-mmd/esm/Runtime/Animation/mmdRuntimeModelAnimationContainer"?`);
             } else {
                 runtimeAnimations.push(null);
             }

--- a/src/Runtime/Animation/mmdRuntimeCameraAnimationContainer.ts
+++ b/src/Runtime/Animation/mmdRuntimeCameraAnimationContainer.ts
@@ -1,6 +1,6 @@
 import type { _IAnimationState } from "@babylonjs/core/Animations/animation";
 
-import { MmdCameraAnimationGroup } from "@/Loader/Animation/mmdCameraAnimationGroup";
+import { MmdCameraAnimationContainer } from "@/Loader/Animation/mmdCameraAnimationContainer";
 
 import type { IMmdCamera } from "../IMmdCamera";
 import { CreateAnimationState } from "./Common/createAnimationState";
@@ -12,11 +12,11 @@ import type { IMmdRuntimeCameraAnimation } from "./IMmdRuntimeAnimation";
  *
  * An object with mmd animation group and camera binding information
  */
-export class MmdRuntimeCameraAnimationGroup implements IMmdRuntimeCameraAnimation {
+export class MmdRuntimeCameraAnimationContainer implements IMmdRuntimeCameraAnimation {
     /**
      * The animation data
      */
-    public readonly animation: MmdCameraAnimationGroup;
+    public readonly animation: MmdCameraAnimationContainer;
 
     private readonly _positionAnimationState: _IAnimationState;
     private readonly _rotationAnimationState: _IAnimationState;
@@ -26,7 +26,7 @@ export class MmdRuntimeCameraAnimationGroup implements IMmdRuntimeCameraAnimatio
     private readonly _camera: IMmdCamera;
 
     private constructor(
-        animation: MmdCameraAnimationGroup,
+        animation: MmdCameraAnimationContainer,
         camera: IMmdCamera
     ) {
         this.animation = animation;
@@ -56,23 +56,23 @@ export class MmdRuntimeCameraAnimationGroup implements IMmdRuntimeCameraAnimatio
      * Bind animation to camera
      * @param animation Animation to bind
      * @param camera Bind target
-     * @returns MmdRuntimeCameraAnimationGroup instance
+     * @returns MmdRuntimeCameraAnimationContainer instance
      */
-    public static Create(animation: MmdCameraAnimationGroup, camera: IMmdCamera): MmdRuntimeCameraAnimationGroup {
-        return new MmdRuntimeCameraAnimationGroup(animation, camera);
+    public static Create(animation: MmdCameraAnimationContainer, camera: IMmdCamera): MmdRuntimeCameraAnimationContainer {
+        return new MmdRuntimeCameraAnimationContainer(animation, camera);
     }
 }
 
-declare module "../../Loader/Animation/mmdCameraAnimationGroup" {
+declare module "../../Loader/Animation/mmdCameraAnimationContainer" {
     // eslint-disable-next-line @typescript-eslint/naming-convention
-    export interface MmdCameraAnimationGroup extends IMmdBindableCameraAnimation<MmdRuntimeCameraAnimationGroup> { }
+    export interface MmdCameraAnimationContainer extends IMmdBindableCameraAnimation<MmdRuntimeCameraAnimationContainer> { }
 }
 
 /**
  * Create runtime camera animation
  * @param camera Bind target
- * @returns MmdRuntimeCameraAnimationGroup instance
+ * @returns MmdRuntimeCameraAnimationContainer instance
  */
-MmdCameraAnimationGroup.prototype.createRuntimeCameraAnimation = function(camera: IMmdCamera): MmdRuntimeCameraAnimationGroup {
-    return MmdRuntimeCameraAnimationGroup.Create(this, camera);
+MmdCameraAnimationContainer.prototype.createRuntimeCameraAnimation = function(camera: IMmdCamera): MmdRuntimeCameraAnimationContainer {
+    return MmdRuntimeCameraAnimationContainer.Create(this, camera);
 };

--- a/src/Runtime/IMmdCamera.ts
+++ b/src/Runtime/IMmdCamera.ts
@@ -7,9 +7,9 @@ import type { IMmdBindableCameraAnimation } from "./Animation/IMmdBindableAnimat
 import type { IMmdRuntimeCameraAnimation } from "./Animation/IMmdRuntimeAnimation";
 import type { MmdCompositeRuntimeCameraAnimation } from "./Animation/mmdCompositeRuntimeCameraAnimation";
 import type { MmdRuntimeCameraAnimation } from "./Animation/mmdRuntimeCameraAnimation";
-import type { MmdRuntimeCameraAnimationGroup } from "./Animation/mmdRuntimeCameraAnimationGroup";
+import type { MmdRuntimeCameraAnimationContainer } from "./Animation/mmdRuntimeCameraAnimationContainer";
 
-type RuntimeCameraAnimation = MmdRuntimeCameraAnimation | MmdRuntimeCameraAnimationGroup | MmdCompositeRuntimeCameraAnimation | IMmdRuntimeCameraAnimation;
+type RuntimeCameraAnimation = MmdRuntimeCameraAnimation | MmdRuntimeCameraAnimationContainer | MmdCompositeRuntimeCameraAnimation | IMmdRuntimeCameraAnimation;
 
 /**
  * Interface for MMD camera

--- a/src/Runtime/Optimized/mmdWasmModel.ts
+++ b/src/Runtime/Optimized/mmdWasmModel.ts
@@ -14,7 +14,7 @@ import type { IMmdBindableModelAnimation } from "../Animation/IMmdBindableAnimat
 import type { IMmdRuntimeModelAnimation } from "../Animation/IMmdRuntimeAnimation";
 import type { MmdCompositeRuntimeModelAnimation } from "../Animation/mmdCompositeRuntimeModelAnimation";
 import type { MmdRuntimeModelAnimation } from "../Animation/mmdRuntimeModelAnimation";
-import type { MmdRuntimeModelAnimationGroup } from "../Animation/mmdRuntimeModelAnimationGroup";
+import type { MmdRuntimeModelAnimationContainer } from "../Animation/mmdRuntimeModelAnimationContainer";
 import type { IMmdMaterialProxyConstructor } from "../IMmdMaterialProxy";
 import type { IMmdModel } from "../IMmdModel";
 import type { IMmdRuntimeBone } from "../IMmdRuntimeBone";
@@ -31,7 +31,7 @@ import type { MmdWasmRuntime } from "./mmdWasmRuntime";
 import { MmdWasmRuntimeAnimationEvaluationType } from "./mmdWasmRuntime";
 import { MmdWasmRuntimeBone } from "./mmdWasmRuntimeBone";
 
-type RuntimeModelAnimation = MmdWasmRuntimeModelAnimation | MmdRuntimeModelAnimation | MmdRuntimeModelAnimationGroup | MmdCompositeRuntimeModelAnimation | IMmdRuntimeModelAnimation;
+type RuntimeModelAnimation = MmdWasmRuntimeModelAnimation | MmdRuntimeModelAnimation | MmdRuntimeModelAnimationContainer | MmdCompositeRuntimeModelAnimation | IMmdRuntimeModelAnimation;
 
 /**
  * MmdWasmModel is a class that controls the `MmdSkinnedMesh` to animate the Mesh with MMD Wasm Runtime
@@ -351,7 +351,7 @@ export class MmdWasmModel implements IMmdModel {
                 this._runtime.warn("MmdWasmAnimation has better performance in the wasm animation runtime. consider importing \"babylon-mmd/esm/Runtime/Optimized/Animation/mmdWasmRuntimeModelAnimation\" instead of \"babylon-mmd/esm/Runtime/Animation/mmdRuntimeModelAnimation\"");
             }
         } else {
-            throw new Error("animation is not MmdWasmAnimation or MmdAnimation or MmdModelAnimationGroup or MmdCompositeAnimation. are you missing import \"babylon-mmd/esm/Runtime/Optimized/Animation/mmdWasmRuntimeModelAnimation\" or \"babylon-mmd/esm/Runtime/Animation/mmdRuntimeModelAnimation\" or \"babylon-mmd/esm/Runtime/Animation/mmdRuntimeModelAnimationGroup\" or \"babylon-mmd/esm/Runtime/Animation/mmdCompositeRuntimeModelAnimation\"?");
+            throw new Error("animation is not MmdWasmAnimation or MmdAnimation or MmdModelAnimationContainer or MmdCompositeAnimation. are you missing import \"babylon-mmd/esm/Runtime/Optimized/Animation/mmdWasmRuntimeModelAnimation\" or \"babylon-mmd/esm/Runtime/Animation/mmdRuntimeModelAnimation\" or \"babylon-mmd/esm/Runtime/Animation/mmdRuntimeModelAnimationContainer\" or \"babylon-mmd/esm/Runtime/Animation/mmdCompositeRuntimeModelAnimation\"?");
         }
 
         const index = this._animations.findIndex((a) => a.animation.name === animation.name);

--- a/src/Runtime/mmdCamera.ts
+++ b/src/Runtime/mmdCamera.ts
@@ -10,14 +10,14 @@ import type { IMmdBindableCameraAnimation } from "./Animation/IMmdBindableAnimat
 import type { IMmdRuntimeCameraAnimation } from "./Animation/IMmdRuntimeAnimation";
 import type { MmdCompositeRuntimeCameraAnimation } from "./Animation/mmdCompositeRuntimeCameraAnimation";
 import type { MmdRuntimeCameraAnimation } from "./Animation/mmdRuntimeCameraAnimation";
-import type { MmdRuntimeCameraAnimationGroup } from "./Animation/mmdRuntimeCameraAnimationGroup";
+import type { MmdRuntimeCameraAnimationContainer } from "./Animation/mmdRuntimeCameraAnimationContainer";
 import type { IMmdCamera } from "./IMmdCamera";
 
 Node.AddNodeConstructor("MmdCamera", (name, scene) => {
     return (): MmdCamera => new MmdCamera(name, undefined, scene);
 });
 
-type RuntimeCameraAnimation = MmdRuntimeCameraAnimation | MmdRuntimeCameraAnimationGroup | MmdCompositeRuntimeCameraAnimation | IMmdRuntimeCameraAnimation;
+type RuntimeCameraAnimation = MmdRuntimeCameraAnimation | MmdRuntimeCameraAnimationContainer | MmdCompositeRuntimeCameraAnimation | IMmdRuntimeCameraAnimation;
 
 /**
  * MMD camera
@@ -84,7 +84,7 @@ export class MmdCamera extends Camera implements IMmdCamera {
         if ((animation as IMmdBindableCameraAnimation).createRuntimeCameraAnimation) {
             runtimeAnimation = animation.createRuntimeCameraAnimation(this);
         } else {
-            throw new Error("animation is not MmdAnimation or MmdCameraAnimationGroup or MmdCompositeAnimation. are you missing import \"babylon-mmd/esm/Runtime/Animation/mmdRuntimeCameraAnimation\" or \"babylon-mmd/esm/Runtime/Animation/mmdRuntimeCameraAnimationGroup\" or \"babylon-mmd/esm/Runtime/Animation/mmdCompositeRuntimeCameraAnimation\"?");
+            throw new Error("animation is not MmdAnimation or MmdCameraAnimationContainer or MmdCompositeAnimation. are you missing import \"babylon-mmd/esm/Runtime/Animation/mmdRuntimeCameraAnimation\" or \"babylon-mmd/esm/Runtime/Animation/mmdRuntimeCameraAnimationContainer\" or \"babylon-mmd/esm/Runtime/Animation/mmdCompositeRuntimeCameraAnimation\"?");
         }
 
         const existingAnimation = this._animationNameMap.get(animation.name);

--- a/src/Runtime/mmdModel.ts
+++ b/src/Runtime/mmdModel.ts
@@ -14,7 +14,7 @@ import type { IMmdBindableModelAnimation } from "./Animation/IMmdBindableAnimati
 import type { IMmdRuntimeModelAnimation } from "./Animation/IMmdRuntimeAnimation";
 import type { MmdCompositeRuntimeModelAnimation } from "./Animation/mmdCompositeRuntimeModelAnimation";
 import type { MmdRuntimeModelAnimation } from "./Animation/mmdRuntimeModelAnimation";
-import type { MmdRuntimeModelAnimationGroup } from "./Animation/mmdRuntimeModelAnimationGroup";
+import type { MmdRuntimeModelAnimationContainer } from "./Animation/mmdRuntimeModelAnimationContainer";
 import { AppendTransformSolver } from "./appendTransformSolver";
 import { IkSolver } from "./ikSolver";
 import type { ILogger } from "./ILogger";
@@ -28,7 +28,7 @@ import type { IMmdModelPhysicsCreationOptions } from "./mmdRuntime";
 import { MmdRuntimeBone } from "./mmdRuntimeBone";
 import type { IMmdPhysics, IMmdPhysicsModel } from "./Physics/IMmdPhysics";
 
-type RuntimeModelAnimation = MmdRuntimeModelAnimation | MmdRuntimeModelAnimationGroup | MmdCompositeRuntimeModelAnimation | IMmdRuntimeModelAnimation;
+type RuntimeModelAnimation = MmdRuntimeModelAnimation | MmdRuntimeModelAnimationContainer | MmdCompositeRuntimeModelAnimation | IMmdRuntimeModelAnimation;
 
 /**
  * Physics options for construct MmdModel
@@ -265,7 +265,7 @@ export class MmdModel implements IMmdModel {
         if ((animation as IMmdBindableModelAnimation).createRuntimeModelAnimation !== undefined) {
             runtimeAnimation = animation.createRuntimeModelAnimation(this, retargetingMap, this._logger);
         } else {
-            throw new Error("animation is not MmdAnimation or MmdModelAnimationGroup or MmdCompositeAnimation. are you missing import \"babylon-mmd/esm/Runtime/Animation/mmdRuntimeModelAnimation\" or \"babylon-mmd/esm/Runtime/Animation/mmdRuntimeModelAnimationGroup\" or \"babylon-mmd/esm/Runtime/Animation/mmdCompositeRuntimeModelAnimation\"?");
+            throw new Error("animation is not MmdAnimation or MmdModelAnimationContainer or MmdCompositeAnimation. are you missing import \"babylon-mmd/esm/Runtime/Animation/mmdRuntimeModelAnimation\" or \"babylon-mmd/esm/Runtime/Animation/mmdRuntimeModelAnimationContainer\" or \"babylon-mmd/esm/Runtime/Animation/mmdCompositeRuntimeModelAnimation\"?");
         }
 
         const index = this._animations.findIndex(a => a.animation.name === animation.name);

--- a/src/Test/Scene/babylonAnimationBlendingTestScene.ts
+++ b/src/Test/Scene/babylonAnimationBlendingTestScene.ts
@@ -2,8 +2,8 @@ import "@babylonjs/core/Animations/animatable";
 import "@babylonjs/core/Loading/loadingScreen";
 import "@babylonjs/core/Rendering/depthRendererSceneComponent";
 import "@/Loader/Optimized/bpmxLoader";
-import "@/Runtime/Animation/mmdRuntimeCameraAnimationGroup";
-import "@/Runtime/Animation/mmdRuntimeModelAnimationGroup";
+import "@/Runtime/Animation/mmdRuntimeCameraAnimationContainer";
+import "@/Runtime/Animation/mmdRuntimeModelAnimationContainer";
 
 import { SkeletonViewer } from "@babylonjs/core/Debug/skeletonViewer";
 import type { AbstractEngine } from "@babylonjs/core/Engines/abstractEngine";
@@ -20,8 +20,8 @@ import { Scene } from "@babylonjs/core/scene";
 import havokPhysics from "@babylonjs/havok";
 
 import type { MmdAnimation } from "@/Loader/Animation/mmdAnimation";
-import { MmdCameraAnimationGroup, MmdCameraAnimationGroupBezierBuilder } from "@/Loader/Animation/mmdCameraAnimationGroup";
-import { MmdModelAnimationGroup, MmdModelAnimationGroupBezierBuilder } from "@/Loader/Animation/mmdModelAnimationGroup";
+import { MmdCameraAnimationContainer, MmdCameraAnimationContainerBezierBuilder } from "@/Loader/Animation/mmdCameraAnimationContainer";
+import { MmdModelAnimationContainer, MmdModelAnimationContainerBezierBuilder } from "@/Loader/Animation/mmdModelAnimationContainer";
 import { MmdStandardMaterialBuilder } from "@/Loader/mmdStandardMaterialBuilder";
 import { BvmdLoader } from "@/Loader/Optimized/bvmdLoader";
 import { SdefInjector } from "@/Loader/sdefInjector";
@@ -152,28 +152,28 @@ export class SceneBuilder implements ISceneBuilder {
         const audioPlayer2 = new StreamAudioPlayer(scene);
         audioPlayer2.source = "res/private_test/motion/conqueror/MMDConquerorIA.mp3";
 
-        const mmdModelAnimationGroup1 = new MmdModelAnimationGroup(mmdAnimation1, new MmdModelAnimationGroupBezierBuilder());
-        const mmdCameraAnimationGroup1 = new MmdCameraAnimationGroup(mmdAnimation1, new MmdCameraAnimationGroupBezierBuilder());
+        const mmdModelAnimationContainer1 = new MmdModelAnimationContainer(mmdAnimation1, new MmdModelAnimationContainerBezierBuilder());
+        const mmdCameraAnimationContainer1 = new MmdCameraAnimationContainer(mmdAnimation1, new MmdCameraAnimationContainerBezierBuilder());
 
-        const mmdModelAnimationGroup2 = new MmdModelAnimationGroup(mmdAnimation2, new MmdModelAnimationGroupBezierBuilder());
-        const mmdCameraAnimationGroup2 = new MmdCameraAnimationGroup(mmdAnimation2, new MmdCameraAnimationGroupBezierBuilder());
+        const mmdModelAnimationContainer2 = new MmdModelAnimationContainer(mmdAnimation2, new MmdModelAnimationContainerBezierBuilder());
+        const mmdCameraAnimationContainer2 = new MmdCameraAnimationContainer(mmdAnimation2, new MmdCameraAnimationContainerBezierBuilder());
 
-        const bindedModelAnimationGroup1 = mmdModelAnimationGroup1.createAnimationGroup(mmdModel);
-        for (const animation of mmdModelAnimationGroup1.propertyAnimations) {
+        const bindedModelAnimationGroup1 = mmdModelAnimationContainer1.createAnimationGroup(mmdModel);
+        for (const animation of mmdModelAnimationContainer1.propertyAnimations) {
             bindedModelAnimationGroup1.removeTargetedAnimation(animation);
         }
-        const bindedCameraAnimationGroup1 = mmdCameraAnimationGroup1.createAnimationGroup(mmdCamera);
+        const bindedCameraAnimationGroup1 = mmdCameraAnimationContainer1.createAnimationGroup(mmdCamera);
 
         // for match animation duration
         bindedModelAnimationGroup1.normalize(mmdAnimation1.startFrame, mmdAnimation1.endFrame);
         bindedCameraAnimationGroup1.normalize(mmdAnimation1.startFrame, mmdAnimation1.endFrame);
 
 
-        const bindedModelAnimationGroup2 = mmdModelAnimationGroup2.createAnimationGroup(mmdModel);
-        for (const animation of mmdModelAnimationGroup2.propertyAnimations) {
+        const bindedModelAnimationGroup2 = mmdModelAnimationContainer2.createAnimationGroup(mmdModel);
+        for (const animation of mmdModelAnimationContainer2.propertyAnimations) {
             bindedModelAnimationGroup2.removeTargetedAnimation(animation);
         }
-        const bindedCameraAnimationGroup2 = mmdCameraAnimationGroup2.createAnimationGroup(mmdCamera);
+        const bindedCameraAnimationGroup2 = mmdCameraAnimationContainer2.createAnimationGroup(mmdCamera);
 
         // for match animation duration
         bindedModelAnimationGroup2.normalize(mmdAnimation2.startFrame, mmdAnimation2.endFrame);

--- a/src/Test/Scene/babylonAnimationTestScene.ts
+++ b/src/Test/Scene/babylonAnimationTestScene.ts
@@ -2,8 +2,8 @@ import "@babylonjs/core/Animations/animatable";
 import "@babylonjs/core/Loading/loadingScreen";
 import "@babylonjs/core/Rendering/depthRendererSceneComponent";
 import "@/Loader/Optimized/bpmxLoader";
-import "@/Runtime/Animation/mmdRuntimeCameraAnimationGroup";
-import "@/Runtime/Animation/mmdRuntimeModelAnimationGroup";
+import "@/Runtime/Animation/mmdRuntimeCameraAnimationContainer";
+import "@/Runtime/Animation/mmdRuntimeModelAnimationContainer";
 
 import { SkeletonViewer } from "@babylonjs/core/Debug/skeletonViewer";
 import type { AbstractEngine } from "@babylonjs/core/Engines/abstractEngine";
@@ -20,8 +20,8 @@ import havokPhysics from "@babylonjs/havok";
 import { Inspector } from "@babylonjs/inspector";
 
 import type { MmdAnimation } from "@/Loader/Animation/mmdAnimation";
-import { MmdCameraAnimationGroup, MmdCameraAnimationGroupBezierBuilder } from "@/Loader/Animation/mmdCameraAnimationGroup";
-import { MmdModelAnimationGroup, MmdModelAnimationGroupBezierBuilder } from "@/Loader/Animation/mmdModelAnimationGroup";
+import { MmdCameraAnimationContainer, MmdCameraAnimationContainerBezierBuilder } from "@/Loader/Animation/mmdCameraAnimationContainer";
+import { MmdModelAnimationContainer, MmdModelAnimationContainerBezierBuilder } from "@/Loader/Animation/mmdModelAnimationContainer";
 import { MmdStandardMaterialBuilder } from "@/Loader/mmdStandardMaterialBuilder";
 import { BvmdLoader } from "@/Loader/Optimized/bvmdLoader";
 import { SdefInjector } from "@/Loader/sdefInjector";
@@ -135,11 +135,11 @@ export class SceneBuilder implements ISceneBuilder {
             buildPhysics: true
         });
 
-        const mmdModelAnimationGroup = new MmdModelAnimationGroup(mmdAnimation, new MmdModelAnimationGroupBezierBuilder());
-        const mmdCameraAnimationGroup = new MmdCameraAnimationGroup(mmdAnimation, new MmdCameraAnimationGroupBezierBuilder());
+        const mmdModelAnimationContainer = new MmdModelAnimationContainer(mmdAnimation, new MmdModelAnimationContainerBezierBuilder());
+        const mmdCameraAnimationContainer = new MmdCameraAnimationContainer(mmdAnimation, new MmdCameraAnimationContainerBezierBuilder());
 
-        mmdModelAnimationGroup.createAnimationGroup(mmdModel).play();
-        mmdCameraAnimationGroup.createAnimationGroup(mmdCamera).play();
+        mmdModelAnimationContainer.createAnimationGroup(mmdModel).play();
+        mmdCameraAnimationContainer.createAnimationGroup(mmdCamera).play();
         audioPlayer.play();
 
         Inspector.Show(scene, { });

--- a/src/Test/Scene/physicsToggleTestScene.ts
+++ b/src/Test/Scene/physicsToggleTestScene.ts
@@ -3,7 +3,7 @@ import "@/Loader/Optimized/bpmxLoader";
 import "@/Loader/mmdOutlineRenderer";
 import "@/Runtime/Optimized/Animation/mmdWasmRuntimeModelAnimation";
 import "@/Runtime/Animation/mmdRuntimeModelAnimation";
-import "@/Runtime/Animation/mmdRuntimeModelAnimationGroup";
+import "@/Runtime/Animation/mmdRuntimeModelAnimationContainer";
 import "@/Runtime/Animation/mmdCompositeRuntimeModelAnimation";
 
 import { PhysicsViewer } from "@babylonjs/core/Debug/physicsViewer";
@@ -20,7 +20,7 @@ import { Scene } from "@babylonjs/core/scene";
 // import havok from "@babylonjs/havok";
 import { Inspector } from "@babylonjs/inspector";
 
-// import { MmdModelAnimationGroup, MmdModelAnimationGroupBezierBuilder } from "@/Loader/Animation/mmdModelAnimationGroup";
+// import { MmdModelAnimationContainer, MmdModelAnimationContainerBezierBuilder } from "@/Loader/Animation/mmdModelAnimationContainer";
 import { SdefInjector } from "@/Loader/sdefInjector";
 import { VmdLoader } from "@/Loader/vmdLoader";
 // import { MmdAnimationSpan, MmdCompositeAnimation } from "@/Runtime/Animation/mmdCompositeAnimation";
@@ -108,11 +108,11 @@ export class SceneBuilder implements ISceneBuilder {
         mmdModel.addAnimation(wasmAnimation);
         mmdModel.setAnimation("motion");
 
-        // const animationGroup = new MmdModelAnimationGroup(animation, new MmdModelAnimationGroupBezierBuilder());
-        // animationGroup
-        // mmdModel.addAnimation(animationGroup);
+        // const animationContainer = new MmdModelAnimationContainer(animation, new MmdModelAnimationContainerBezierBuilder());
+        // animationContainer
+        // mmdModel.addAnimation(animationContainer);
         // mmdModel.setAnimation("motion");
-        // animationGroup.createAnimationGroup(mmdModel).play();
+        // animationContainer.createAnimationGroup(mmdModel).play();
 
         // const compositeAnimation = new MmdCompositeAnimation("composite");
         // compositeAnimation.addSpan(new MmdAnimationSpan(wasmAnimation));

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,9 +2,9 @@ import "@/Loader/mmdOutlineRenderer";
 import "@/Runtime/Animation/mmdCompositeRuntimeCameraAnimation";
 import "@/Runtime/Animation/mmdCompositeRuntimeModelAnimation";
 import "@/Runtime/Animation/mmdRuntimeCameraAnimation";
-import "@/Runtime/Animation/mmdRuntimeCameraAnimationGroup";
+import "@/Runtime/Animation/mmdRuntimeCameraAnimationContainer";
 import "@/Runtime/Animation/mmdRuntimeModelAnimation";
-import "@/Runtime/Animation/mmdRuntimeModelAnimationGroup";
+import "@/Runtime/Animation/mmdRuntimeModelAnimationContainer";
 import "@/Runtime/Optimized/Animation/mmdWasmRuntimeModelAnimation";
 // for serialization
 import "@/Loader/mmdPluginMaterial";
@@ -24,8 +24,8 @@ export { IMmdAnimation } from "@/Loader/Animation/IMmdAnimation";
 export { MmdAnimation } from "@/Loader/Animation/mmdAnimation";
 export { MmdAnimationBase } from "@/Loader/Animation/mmdAnimationBase";
 export { MmdAnimationTrack, MmdBoneAnimationTrack, MmdCameraAnimationTrack, MmdMorphAnimationTrack, MmdMovableBoneAnimationTrack, MmdPropertyAnimationTrack } from "@/Loader/Animation/mmdAnimationTrack";
-export { IMmdCameraAnimationGroupBuilder, MmdCameraAnimationGroup, MmdCameraAnimationGroupBezierBuilder, MmdCameraAnimationGroupHermiteBuilder, MmdCameraAnimationGroupSampleBuilder } from "@/Loader/Animation/mmdCameraAnimationGroup";
-export { IMmdModelAnimationGroupBuilder, MmdModelAnimationGroup, MmdModelAnimationGroupBezierBuilder, MmdModelAnimationGroupHermiteBuilder, MmdModelAnimationGroupSampleBuilder } from "@/Loader/Animation/mmdModelAnimationGroup";
+export { IMmdCameraAnimationContainerBuilder, MmdCameraAnimationContainer, MmdCameraAnimationContainerBezierBuilder, MmdCameraAnimationContainerHermiteBuilder, MmdCameraAnimationContainerSampleBuilder } from "@/Loader/Animation/mmdCameraAnimationContainer";
+export { IMmdModelAnimationContainerBuilder, MmdModelAnimationContainer, MmdModelAnimationContainerBezierBuilder, MmdModelAnimationContainerHermiteBuilder, MmdModelAnimationContainerSampleBuilder } from "@/Loader/Animation/mmdModelAnimationContainer";
 
 // Loader/Optimized/Parser
 export { BpmxObject } from "@/Loader/Optimized/Parser/bpmxObject";
@@ -82,9 +82,9 @@ export { MmdCompositeRuntimeCameraAnimation } from "@/Runtime/Animation/mmdCompo
 export { MmdCompositeRuntimeModelAnimation } from "@/Runtime/Animation/mmdCompositeRuntimeModelAnimation";
 export { MmdRuntimeAnimation } from "@/Runtime/Animation/mmdRuntimeAnimation";
 export { MmdRuntimeCameraAnimation } from "@/Runtime/Animation/mmdRuntimeCameraAnimation";
-export { MmdRuntimeCameraAnimationGroup } from "@/Runtime/Animation/mmdRuntimeCameraAnimationGroup";
+export { MmdRuntimeCameraAnimationContainer } from "@/Runtime/Animation/mmdRuntimeCameraAnimationContainer";
 export { MmdRuntimeModelAnimation } from "@/Runtime/Animation/mmdRuntimeModelAnimation";
-export { MmdRuntimeModelAnimationGroup } from "@/Runtime/Animation/mmdRuntimeModelAnimationGroup";
+export { MmdRuntimeModelAnimationContainer } from "@/Runtime/Animation/mmdRuntimeModelAnimationContainer";
 
 // Runtime/Audio
 export { IPlayer } from "@/Runtime/Audio/IAudioPlayer";


### PR DESCRIPTION
MmdXXXAnimationGroup doesn't actually mean an AnimationGroup in Babylon.js, it actually means a builder of AnimationGroup and at the same time an Animation Container that we can put in MmdRuntime.

So we rename it to Animation Container.