### PR TITLE
feat: add option to preserve IK solver states across animation changes

### DIFF
--- a/src/Runtime/Optimized/mmdWasmModel.ts
+++ b/src/Runtime/Optimized/mmdWasmModel.ts
@@ -157,6 +157,13 @@ export class MmdWasmModel implements IMmdModel {
     private _needStateReset: boolean;
 
     /**
+     * When true, IK solver states are preserved when switching animations.
+     * Useful for timeline clip playback where IK override mode should persist across animation changes.
+     * @default false
+     */
+    public preserveIkStatesOnAnimationChange = false;
+
+    /**
      * Create a MmdWasmModel
      *
      * IMPORTANT: when wasm runtime using buffered evaluation, this constructor must be called before waiting for the WasmMmdRuntime.lock
@@ -477,7 +484,9 @@ export class MmdWasmModel implements IMmdModel {
             if (this._needStateReset) {
                 this._needStateReset = false;
 
-                this.ikSolverStates.fill(1);
+                if (!this.preserveIkStatesOnAnimationChange) {
+                    this.ikSolverStates.fill(1);
+                }
                 this.morph.resetMorphWeights();
             }
 

--- a/src/Runtime/mmdModel.ts
+++ b/src/Runtime/mmdModel.ts
@@ -119,6 +119,13 @@ export class MmdModel implements IMmdModel {
     private _needStateReset: boolean;
 
     /**
+     * When true, IK solver states are preserved when switching animations.
+     * Useful for timeline clip playback where IK override mode should persist across animation changes.
+     * @default false
+     */
+    public preserveIkStatesOnAnimationChange = false;
+
+    /**
      * Create a MmdModel
      * @param mmdSkinnedMesh Mesh that able to instantiate `MmdModel`
      * @param skeleton The virtualized bone container of the mesh
@@ -372,8 +379,10 @@ export class MmdModel implements IMmdModel {
                 this._needStateReset = false;
 
                 this.morph.resetMorphWeights();
-                this.ikSolverStates.fill(1);
-                this.rigidBodyStates.fill(1);
+                if (!this.preserveIkStatesOnAnimationChange) {
+                    this.ikSolverStates.fill(1);
+                    this.rigidBodyStates.fill(1);
+                }
             }
 
             if (this._currentAnimation !== null) {


### PR DESCRIPTION
## Summary

Adds a new public property `preserveIkStatesOnAnimationChange` to both `MmdModel` and `MmdWasmModel` classes that allows IK solver states to persist when switching animations.

### Changes
- Added `preserveIkStatesOnAnimationChange: boolean` property (default: `false`) to `MmdModel`
- Added `preserveIkStatesOnAnimationChange: boolean` property (default: `false`) to `MmdWasmModel`
- When set to `true`, IK solver states (and rigid body states for `MmdModel`) are not reset when switching animations

### Use Case
This is useful for timeline/clip playback scenarios where:
- Users want to maintain custom IK configurations throughout playback
- IK override mode should persist across animation clip changes
- Multiple animation clips are played in sequence and IK states should be preserved

### Example Usage
```typescript
const model = runtime.createMmdModel(mesh);
model.preserveIkStatesOnAnimationChange = true;

// IK states will now persist when switching animations
model.setRuntimeAnimation(clip1Handle);
// ... later ...
model.setRuntimeAnimation(clip2Handle); // IK states preserved
```

### Backward Compatibility
- Default value is `false`, maintaining existing behavior
- No breaking changes to existing API

🤖 Generated with [Claude Code](https://claude.ai/code)